### PR TITLE
Separate out development and production settings into different files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cd federal-grant-reporting
 cd single-audit
 pipenv shell
 pipenv install
-./manage.py runserver
+./manage.py runserver --settings=single_audit.settings.development
 ```
 
 The app should now be running at http://localhost:8000 or http://127.0.0.1:8000.

--- a/single-audit/manage.py
+++ b/single-audit/manage.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'single_audit.settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/single-audit/single_audit/settings.py
+++ b/single-audit/single_audit/settings.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     'localflavor',
     'fac.apps.FacConfig',
     'distiller.apps.DistillerConfig',
-    'resolve_findings.apps.ResolveFindingsConfig',
 ]
 
 MIDDLEWARE = [

--- a/single-audit/single_audit/settings/base.py
+++ b/single-audit/single_audit/settings/base.py
@@ -16,15 +16,6 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'SECRET'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
 ALLOWED_HOSTS = []
 
 
@@ -72,24 +63,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'single_audit.wsgi.application'
-
-
-# Database
-# https://docs.djangoproject.com/en/2.1/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'SECRET',
-        'USER': 'SECRET',
-        'PASSWORD': 'SECRET',
-        'HOST': '127.0.0.1',
-        'PORT': '5432',
-        'TEST': {
-            'NAME': 'test_SECRET',
-        }
-    }
-}
 
 
 # Password validation

--- a/single-audit/single_audit/settings/development.py
+++ b/single-audit/single_audit/settings/development.py
@@ -1,0 +1,22 @@
+from .base import *
+
+DEBUG = True
+
+SECRET_KEY = 'SECRET'
+
+# Database
+# https://docs.djangoproject.com/en/2.1/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'FGR_LOCAL_DB',
+        'USER': 'FGR_LOCAL_USER',
+        'PASSWORD': 'SECRET',
+        'HOST': '127.0.0.1',
+        'PORT': '5432',
+        'TEST': {
+            'NAME': 'test_SECRET',
+        }
+    }
+}

--- a/single-audit/single_audit/settings/production.py
+++ b/single-audit/single_audit/settings/production.py
@@ -1,0 +1,17 @@
+from .base import *
+
+SECRET_KEY = os.environ.get('SECRET_KEY')
+
+# Database
+# https://docs.djangoproject.com/en/2.1/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ.get('DATABASE_NAME'),
+        'USER': os.environ.get('DATABASE_USER'),
+        'PASSWORD': os.environ.get('DATABASE_PASSWORD'),
+        'HOST': os.environ.get('DATABASE_HOST'),
+        'PORT': '5432',
+    }
+}


### PR DESCRIPTION
# Notes

+ Builds on @fureigh's work adding `settings.py` #83.
+ Use hard-coded values for development; ENV variables for production. 
